### PR TITLE
Add data() method to CalendarSelect for custom data attributes

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -2,6 +2,12 @@ MD013:
   line_length: 180
   code_blocks: false
   tables: false
+MD024:
+  siblings_only: true
+MD025:
+  front_matter_title: ""
+MD029:
+  style: one_or_ordered
 MD033:
   allowed_elements:
     - img
@@ -18,10 +24,9 @@ MD033:
     - ol
     - kbd
     - style
+MD036: false
 MD041: false
 MD046:
   style: fenced
-MD029:
-  style: one
-MD025:
-  front_matter_title: ""
+MD060:
+  style: aligned

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,10 @@ This is a PHP library providing reusable frontend components for the Liturgical 
 - `ApiOptions`: Form inputs for API request parameters
 - `WebCalendar`: Display components for liturgical calendar data
 
+This library is part of the coordinated API client libraries effort.
+See the [API Client Libraries Roadmap](../docs/API_CLIENT_LIBRARIES_ROADMAP.md)
+for the full coordination strategy across PHP, JavaScript, and React platforms.
+
 ## PHP Requirements
 
 - **PHP Version**: >= 8.1 (required for Enum support)
@@ -50,6 +54,7 @@ This is a PHP library providing reusable frontend components for the Liturgical 
   - Ordered lists use consistent numbering style
   - Lists must be surrounded by blank lines
   - Headings must be surrounded by blank lines
+  - Table columns must be vertically aligned (MD060)
   - Inline HTML is allowed for specific elements (img, a, b, table, etc.)
 
 ### Before Committing
@@ -805,3 +810,73 @@ Components primarily work with JSON responses and should handle the data structu
 - Always test with both PHP 8.1 and latest PHP versions when possible
 - Weblate is used for translations (ApiOptions and WebCalendar)
 - Component output should be HTML strings, not echo'd directly
+
+## TODO - Planned Features
+
+### LiturgyOfAnyDay Component
+
+Add a `LiturgyOfAnyDay` component similar to the JavaScript library's implementation. This component should:
+
+- Display liturgical events for any selected date
+- Include `DayInput`, `MonthInput`, and `YearInput` sub-components for date selection
+- Automatically handle December 31st special case (fetch with `year_type=LITURGICAL` and `year+1` for vigil masses)
+- Cache calendar data and re-render when day/month changes (no API call needed)
+- Trigger API refetch only when year changes or year_type needs to change
+- Support high-contrast text colors based on liturgical color backgrounds
+- Add border for white backgrounds to distinguish from parent
+
+**Reference:** See `liturgy-components-js/src/LiturgyOfAnyDay/LiturgyOfAnyDay.js` for implementation patterns.
+
+**Configuration Methods to Implement:**
+
+```php
+$liturgyOfAnyDay = new LiturgyOfAnyDay(['locale' => 'en'])
+    ->id('liturgyOfAnyDay')
+    ->class('card shadow')
+    ->titleClass('h3')
+    ->dateClass('card-header')
+    ->dateControlsClass('row g-3 p-3')
+    ->eventsWrapperClass('card-body')
+    ->eventClass('p-3 mb-2 rounded')
+    ->eventGradeClass('small')
+    ->eventCommonClass('small fst-italic')
+    ->eventYearCycleClass('small')
+    ->dayInputConfig([...])
+    ->monthInputConfig([...])
+    ->yearInputConfig([...])
+    ->buildDateControls();
+
+echo $liturgyOfAnyDay;
+```
+
+### Lightweight JavaScript Client for PHP Components
+
+Create a lightweight JavaScript client (`liturgy-components-php-js`) that complements the PHP component library for reactive UI updates. This would:
+
+- Provide event-driven communication similar to `liturgy-components-js` but designed to work with server-rendered PHP components
+- Allow PHP-rendered components to become reactive without a full JavaScript component library
+- Wire `ApiClient`, `CalendarSelect`, `ApiOptions`, and display components together
+- Handle the component communication patterns:
+
+```javascript
+// Initialize from PHP-rendered HTML
+const apiClient = await LitCalPhpClient.init(BaseUrl);
+
+// Wire components together by DOM selectors
+apiClient.listenTo('#calendarSelect').listenTo('#apiOptions');
+document.querySelector('#liturgyOfAnyDay').listenTo(apiClient);
+```
+
+**Benefits:**
+
+- PHP handles initial rendering (SEO-friendly, fast initial load)
+- JavaScript adds reactivity without duplicating component logic
+- Smaller bundle size than full JS component library
+- Consistent API with `liturgy-components-js` patterns
+
+**Implementation Approach:**
+
+1. Create event listeners for PHP-rendered form elements
+2. Emit events on changes that match `liturgy-components-js` event patterns
+3. Provide `listenTo()` pattern for wiring components
+4. Re-render PHP templates via AJAX or use existing DOM manipulation

--- a/README.md
+++ b/README.md
@@ -263,6 +263,10 @@ with the following keys:
 - `labelText`: The text to use for the label element, default `"Select a calendar"`.
 - `allowNull`: Whether an option with an empty value should be added as the first option of the select, to allow the user to submit a null value, default `false`.
 - `disabled`: Whether to set the `disabled` attribute on the select element, default `false`.
+- `data`: An associative array of data attributes to add to the select element. Keys are the attribute names (without the `data-` prefix)
+  and values are the attribute values. Keys must start with a letter and may contain letters, digits, hyphens, underscores, or colons.
+  Keys are converted to lowercase for HTML5 compliance. Empty string values render as boolean attributes (e.g., `data-requires-auth`),
+  while non-empty values render with quotes (e.g., `data-type="national"`).
 
 > [!CAUTION]
 > When `setOptions` is set to `OptionsType::DIOCESES_FOR_NATION`, the `nationFilter` option MUST also be set, otherwise an exception will occur.
@@ -300,7 +304,15 @@ use LiturgicalCalendar\Components\CalendarSelect;
 use LiturgicalCalendar\Components\CalendarSelect\OptionsType;
 
 $CalendarSelect = new CalendarSelect();
-$CalendarSelect->nationFilter('NL')->setOptions(OptionsType::DIOCESES_FOR_NATION)->locale('it')->class('form-select')->id('diocesan_calendar')->name('diocesan_calendar')->label(true)->labelText('diocese');
+$CalendarSelect->nationFilter('NL')
+    ->setOptions(OptionsType::DIOCESES_FOR_NATION)
+    ->locale('it')
+    ->class('form-select')
+    ->id('diocesan_calendar')
+    ->name('diocesan_calendar')
+    ->label(true)
+    ->labelText('diocese')
+    ->data(['requires-auth' => '', 'calendar-type' => 'diocesan']);
 
 echo $CalendarSelect->getSelect();
 ```

--- a/src/CalendarSelect.php
+++ b/src/CalendarSelect.php
@@ -38,6 +38,7 @@ use Psr\SimpleCache\CacheInterface;
  * - {@see LiturgicalCalendar\Components\CalendarSelect::labelText()} Sets the text for the label.
  * - {@see LiturgicalCalendar\Components\CalendarSelect::allowNull()} Allows or disallows null selection.
  * - {@see LiturgicalCalendar\Components\CalendarSelect::disabled()} Sets whether the select element is disabled.
+ * - {@see LiturgicalCalendar\Components\CalendarSelect::data()} Sets data attributes for the select element.
  * - {@see LiturgicalCalendar\Components\CalendarSelect::isValidLocale()} Checks if the given locale is valid.
  * - {@see LiturgicalCalendar\Components\CalendarSelect::getSelect()} Returns the HTML for the select element.
  * - {@see LiturgicalCalendar\Components\CalendarSelect::getLocale()} Returns the locale used by the calendar select instance.
@@ -77,6 +78,9 @@ class CalendarSelect
     private bool $allowNull                        = false;
     private bool $disabled                         = false;
     private OptionsType $optionsType               = OptionsType::ALL;
+
+    /** @var array<string,string> $dataAttributes Data attributes (name => value, without 'data-' prefix) */
+    private array $dataAttributes = [];
 
     /**
      * Creates a new instance of the CalendarSelect class.
@@ -399,6 +403,32 @@ class CalendarSelect
     }
 
     /**
+     * Sets data attributes for the select element.
+     *
+     * This method accepts an associative array where the keys are the data attribute names
+     * (without the 'data-' prefix) and the values are the corresponding attribute values.
+     * These data attributes will be rendered as 'data-*' attributes in the HTML select element.
+     *
+     * Example:
+     * ```php
+     * $calendarSelect->data(['requires-auth' => '', 'calendar-type' => 'national']);
+     * // Renders: <select ... data-requires-auth data-calendar-type="national">
+     * ```
+     *
+     * @param array<string,string> $data An associative array representing data attributes for the select element.
+     *
+     * @return $this
+     */
+    public function data(array $data): self
+    {
+        $this->dataAttributes = array_map(
+            fn(string $value) => htmlspecialchars($value, ENT_QUOTES, 'UTF-8'),
+            $data
+        );
+        return $this;
+    }
+
+    /**
      * Returns true if the given locale is valid, and false otherwise.
      *
      * A locale is valid if it is either 'la' or 'la_VA' (for Latin) or
@@ -603,6 +633,32 @@ class CalendarSelect
     }
 
     /**
+     * Returns the data-* attributes string for the select element.
+     *
+     * If no data attributes are set, an empty string is returned.
+     * Otherwise, returns a space-prefixed string of all data attributes.
+     *
+     * @return string The data-* attributes string.
+     */
+    private function getData(): string
+    {
+        if (empty($this->dataAttributes)) {
+            return '';
+        }
+        $data = array_map(
+            function (string $key, string $value): string {
+                if ($value === '') {
+                    return "data-{$key}";
+                }
+                return "data-{$key}=\"{$value}\"";
+            },
+            array_keys($this->dataAttributes),
+            array_values($this->dataAttributes)
+        );
+        return ' ' . implode(' ', $data);
+    }
+
+    /**
      * Returns a complete HTML select element for the given options.
      *
      * @return string The HTML for the select element.
@@ -613,13 +669,14 @@ class CalendarSelect
         $id          = $this->id && !empty($this->id) ? " id=\"{$this->id}\"" : '';
         $name        = $this->name && !empty($this->name) ? " name=\"{$this->name}\"" : '';
         $class       = $this->class && !empty($this->class) ? " class=\"{$this->class}\"" : '';
-        $disabled    = $this->disabled ? 'disabled' : '';
+        $disabled    = $this->disabled ? ' disabled' : '';
+        $dataAttrs   = $this->getData();
         $optionsHtml = $this->getOptions();
         if ($this->allowNull) {
             $optionsHtml = "<option value=\"\">---</option>{$optionsHtml}";
         }
         return ( $this->label ? "<label for=\"{$this->id}\"{$labelClass}>{$this->labelStr}</label>" : '' )
-            . "<select{$id}{$name}{$class}{$disabled}>{$optionsHtml}</select>";
+            . "<select{$id}{$name}{$class}{$disabled}{$dataAttrs}>{$optionsHtml}</select>";
     }
 
     /**

--- a/src/CalendarSelect.php
+++ b/src/CalendarSelect.php
@@ -420,7 +420,8 @@ class CalendarSelect
      *
      * @param array<string,string> $data An associative array representing data attributes for the select element.
      *                                   Keys must start with a letter and may then contain letters, digits,
-     *                                   hyphens, underscores, or colons.
+     *                                   hyphens, underscores, or colons. Keys are converted to lowercase
+     *                                   for HTML5 compliance.
      *
      * @return $this
      *
@@ -433,7 +434,8 @@ class CalendarSelect
             if (!is_string($key) || !preg_match('/^[A-Za-z][A-Za-z0-9_\-:]*$/', $key)) {
                 throw new \InvalidArgumentException('Invalid data attribute name: ' . (string) $key);
             }
-            $this->dataAttributes[$key] = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+            // Convert to lowercase for HTML5 compliance
+            $this->dataAttributes[strtolower($key)] = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
         }
         return $this;
     }

--- a/src/CalendarSelect.php
+++ b/src/CalendarSelect.php
@@ -419,7 +419,8 @@ class CalendarSelect
      * ```
      *
      * @param array<string,string> $data An associative array representing data attributes for the select element.
-     *                                   Keys must contain only letters, digits, hyphens, underscores, or colons.
+     *                                   Keys must start with a letter and may then contain letters, digits,
+     *                                   hyphens, underscores, or colons.
      *
      * @return $this
      *

--- a/src/CalendarSelect.php
+++ b/src/CalendarSelect.php
@@ -409,6 +409,9 @@ class CalendarSelect
      * (without the 'data-' prefix) and the values are the corresponding attribute values.
      * These data attributes will be rendered as 'data-*' attributes in the HTML select element.
      *
+     * **Note:** Each call to this method replaces any previously set data attributes.
+     * To add multiple attributes, pass them all in a single array.
+     *
      * Example:
      * ```php
      * $calendarSelect->data(['requires-auth' => '', 'calendar-type' => 'national']);
@@ -416,15 +419,21 @@ class CalendarSelect
      * ```
      *
      * @param array<string,string> $data An associative array representing data attributes for the select element.
+     *                                   Keys must contain only letters, digits, hyphens, underscores, or colons.
      *
      * @return $this
+     *
+     * @throws \InvalidArgumentException If an attribute name contains invalid characters.
      */
     public function data(array $data): self
     {
-        $this->dataAttributes = array_map(
-            fn(string $value) => htmlspecialchars($value, ENT_QUOTES, 'UTF-8'),
-            $data
-        );
+        $this->dataAttributes = [];
+        foreach ($data as $key => $value) {
+            if (!is_string($key) || !preg_match('/^[A-Za-z][A-Za-z0-9_\-:]*$/', $key)) {
+                throw new \InvalidArgumentException('Invalid data attribute name: ' . (string) $key);
+            }
+            $this->dataAttributes[$key] = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+        }
         return $this;
     }
 

--- a/tests/CalendarSelectTest.php
+++ b/tests/CalendarSelectTest.php
@@ -164,7 +164,7 @@ class CalendarSelectTest extends TestCase
     public function testDataMethodAcceptsValidAttributeNames()
     {
         $calendarSelect = new CalendarSelect();
-        // Should not throw - valid attribute names
+        // Should not throw - valid attribute names (note: keys are converted to lowercase)
         $calendarSelect->data([
             'simple'       => 'value1',
             'with-hyphen'  => 'value2',
@@ -176,7 +176,7 @@ class CalendarSelectTest extends TestCase
         $this->assertStringContainsString('data-simple="value1"', $selectHtml);
         $this->assertStringContainsString('data-with-hyphen="value2"', $selectHtml);
         $this->assertStringContainsString('data-with_under="value3"', $selectHtml);
-        $this->assertStringContainsString('data-withNumbers1="value4"', $selectHtml);
+        $this->assertStringContainsString('data-withnumbers1="value4"', $selectHtml);
         $this->assertStringContainsString('data-name:space="value5"', $selectHtml);
     }
 
@@ -189,5 +189,17 @@ class CalendarSelectTest extends TestCase
         // Second call should replace, not merge
         $this->assertStringNotContainsString('data-first', $selectHtml);
         $this->assertStringContainsString('data-second="value2"', $selectHtml);
+    }
+
+    public function testDataMethodConvertsKeysToLowercase()
+    {
+        $calendarSelect = new CalendarSelect();
+        $calendarSelect->data(['CamelCase' => 'value1', 'UPPERCASE' => 'value2']);
+        $selectHtml = $calendarSelect->getSelect();
+        // Keys should be converted to lowercase for HTML5 compliance
+        $this->assertStringContainsString('data-camelcase="value1"', $selectHtml);
+        $this->assertStringContainsString('data-uppercase="value2"', $selectHtml);
+        $this->assertStringNotContainsString('data-CamelCase', $selectHtml);
+        $this->assertStringNotContainsString('data-UPPERCASE', $selectHtml);
     }
 }

--- a/tests/CalendarSelectTest.php
+++ b/tests/CalendarSelectTest.php
@@ -78,4 +78,66 @@ class CalendarSelectTest extends TestCase
         $this->assertTrue(CalendarSelect::isValidLocale('es_ES'));
         $this->assertFalse(CalendarSelect::isValidLocale(' invalid-locale '));
     }
+
+    public function testDataMethodWithValueAttribute()
+    {
+        $calendarSelect = new CalendarSelect();
+        $calendarSelect->data(['calendar-type' => 'national']);
+        $selectHtml = $calendarSelect->getSelect();
+        $this->assertStringContainsString('data-calendar-type="national"', $selectHtml);
+    }
+
+    public function testDataMethodWithEmptyValueAttribute()
+    {
+        $calendarSelect = new CalendarSelect();
+        $calendarSelect->data(['requires-auth' => '']);
+        $selectHtml = $calendarSelect->getSelect();
+        $this->assertStringContainsString('data-requires-auth', $selectHtml);
+        $this->assertStringNotContainsString('data-requires-auth=""', $selectHtml);
+    }
+
+    public function testDataMethodWithMultipleAttributes()
+    {
+        $calendarSelect = new CalendarSelect();
+        $calendarSelect->data([
+            'requires-auth' => '',
+            'calendar-type' => 'national',
+            'api-version'   => '2.0'
+        ]);
+        $selectHtml = $calendarSelect->getSelect();
+        $this->assertStringContainsString('data-requires-auth', $selectHtml);
+        $this->assertStringContainsString('data-calendar-type="national"', $selectHtml);
+        $this->assertStringContainsString('data-api-version="2.0"', $selectHtml);
+    }
+
+    public function testDataMethodChaining()
+    {
+        $calendarSelect = new CalendarSelect();
+        $result         = $calendarSelect
+            ->class('form-select')
+            ->data(['requires-auth' => ''])
+            ->id('mySelect');
+        $this->assertSame($calendarSelect, $result);
+        $selectHtml = $calendarSelect->getSelect();
+        $this->assertStringContainsString('class="form-select"', $selectHtml);
+        $this->assertStringContainsString('data-requires-auth', $selectHtml);
+        $this->assertStringContainsString('id="mySelect"', $selectHtml);
+    }
+
+    public function testDataMethodEscapesHtml()
+    {
+        $calendarSelect = new CalendarSelect();
+        $calendarSelect->data(['test-attr' => '<script>alert("xss")</script>']);
+        $selectHtml = $calendarSelect->getSelect();
+        $this->assertStringNotContainsString('<script>', $selectHtml);
+        $this->assertStringContainsString('&lt;script&gt;', $selectHtml);
+    }
+
+    public function testDataMethodWithNoAttributes()
+    {
+        $calendarSelect = new CalendarSelect();
+        $selectHtml     = $calendarSelect->getSelect();
+        // Ensure there are no stray data- attributes when none are set
+        $this->assertMatchesRegularExpression('/<select[^>]*>/', $selectHtml);
+    }
 }

--- a/tests/CalendarSelectTest.php
+++ b/tests/CalendarSelectTest.php
@@ -139,5 +139,55 @@ class CalendarSelectTest extends TestCase
         $selectHtml     = $calendarSelect->getSelect();
         // Ensure there are no stray data- attributes when none are set
         $this->assertMatchesRegularExpression('/<select[^>]*>/', $selectHtml);
+        // Check that no data- attributes appear on the select element itself
+        preg_match('/<select[^>]*>/', $selectHtml, $matches);
+        $this->assertNotEmpty($matches);
+        $this->assertStringNotContainsString('data-', $matches[0]);
+    }
+
+    public function testDataMethodRejectsInvalidAttributeName()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid data attribute name');
+        $calendarSelect = new CalendarSelect();
+        $calendarSelect->data(['invalid<name' => 'value']);
+    }
+
+    public function testDataMethodRejectsAttributeNameStartingWithNumber()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid data attribute name');
+        $calendarSelect = new CalendarSelect();
+        $calendarSelect->data(['123invalid' => 'value']);
+    }
+
+    public function testDataMethodAcceptsValidAttributeNames()
+    {
+        $calendarSelect = new CalendarSelect();
+        // Should not throw - valid attribute names
+        $calendarSelect->data([
+            'simple'       => 'value1',
+            'with-hyphen'  => 'value2',
+            'with_under'   => 'value3',
+            'withNumbers1' => 'value4',
+            'name:space'   => 'value5'
+        ]);
+        $selectHtml = $calendarSelect->getSelect();
+        $this->assertStringContainsString('data-simple="value1"', $selectHtml);
+        $this->assertStringContainsString('data-with-hyphen="value2"', $selectHtml);
+        $this->assertStringContainsString('data-with_under="value3"', $selectHtml);
+        $this->assertStringContainsString('data-withNumbers1="value4"', $selectHtml);
+        $this->assertStringContainsString('data-name:space="value5"', $selectHtml);
+    }
+
+    public function testDataMethodReplacesNotMerges()
+    {
+        $calendarSelect = new CalendarSelect();
+        $calendarSelect->data(['first' => 'value1']);
+        $calendarSelect->data(['second' => 'value2']);
+        $selectHtml = $calendarSelect->getSelect();
+        // Second call should replace, not merge
+        $this->assertStringNotContainsString('data-first', $selectHtml);
+        $this->assertStringContainsString('data-second="value2"', $selectHtml);
     }
 }


### PR DESCRIPTION
## Summary

- Adds a chainable `data()` method to `CalendarSelect` that accepts an associative array of data attribute names and values
- Empty values render as boolean attributes (e.g., `data-requires-auth`)
- Non-empty values render with quotes (e.g., `data-type="national"`)
- All values are HTML-escaped for XSS protection

## Test plan

- [x] Run `composer test` - all tests pass including 6 new test cases
- [x] Run `composer analyse` - PHPStan level 10 passes
- [x] Run `composer lint` - code style compliant

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calendar select supports custom HTML data-* attributes with validation and automatic HTML-escaping.

* **Tests**
  * Added extensive unit tests covering rendering, multiple attributes, chaining behavior, escaping, validation, and replacement.

* **Documentation**
  * README and docs updated with data-* usage examples and a caution about option ordering; added planning notes and roadmap coordination.

* **Style**
  * Updated Markdown linting rules and table alignment preferences.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->