### PR TITLE
Add prettier for markdown, and repair the fences it uncovered

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+# Prettier is used in this project for MARKDOWN ONLY — see the `format:md` /
+# `format:md:fix` scripts in package.json. It is deliberately NOT wired up for
+# PHP (there is no prettier PHP parser installed) and there is intentionally no
+# .prettierrc, so that an editor's format-on-save does not silently start
+# reformatting source files against prettier's defaults instead of the PSR-12
+# ruleset phpcs enforces.
+
+# Dependencies and build output
+vendor/
+node_modules/
+
+# Compiled gettext catalogues and their sources
+src/**/i18n/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,13 +70,20 @@ composer parallel-lint     # Check PHP syntax
 composer test              # Run full test suite
 composer test:quick        # Run tests excluding slow tests
 
-# Markdown Quality Checks
-composer lint:md           # Check markdown formatting (markdownlint)
-composer lint:md:fix       # Auto-fix markdown formatting
+# Markdown Quality Checks — two tools, different jobs
+composer lint:md           # markdownlint-cli2: check against .markdownlint.yml
+composer lint:md:fix       # markdownlint-cli2 --fix (cannot fix MD060 table alignment)
+composer format:md         # prettier: check formatting, changes nothing
+composer format:md:fix     # prettier: reformat in place (this is what fixes MD060)
 ```
 
-**CRITICAL**: When you create or edit markdown files (*.md), you MUST run `composer lint:md:fix` before committing to ensure proper formatting.
+**CRITICAL**: When you create or edit markdown files (*.md), you MUST run `composer format:md:fix` and then `composer lint:md` before committing.
 The pre-commit hook will block commits with markdown formatting errors.
+
+Run them in that order. They are complementary, not alternatives: `markdownlint-cli2 --fix` **cannot repair MD060** table alignment — it reports the
+error and changes nothing — while prettier does it mechanically, and its output passes `lint:md` with zero errors. Prettier does not fix MD013 line
+length; that still needs a human edit. See [MARKDOWN_LINTING.md](MARKDOWN_LINTING.md) for why prettier is markdown-only and why there is deliberately
+no `.prettierrc`.
 
 ### Markdown File Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,9 +90,10 @@ no `.prettierrc`.
 When creating or editing markdown files, follow this workflow:
 
 1. **Create/Edit** the markdown file
-1. **Auto-fix formatting**: Run `composer lint:md:fix` immediately after editing
+1. **Format**: Run `composer format:md:fix` first — prettier owns table alignment (MD060) and blank lines
+1. **Auto-fix the rest**: Run `composer lint:md:fix` for the rules prettier does not own
 1. **Verify**: Run `composer lint:md` to check for any remaining issues
-1. **Fix manually** if auto-fix couldn't resolve all issues
+1. **Fix manually** what neither can resolve — MD013 line length in particular, since prettier runs with `--prose-wrap=preserve`
 1. **Commit**: The pre-commit hook will verify formatting
 
 **Common markdown linting errors**:
@@ -146,7 +147,7 @@ See [MARKDOWN_LINTING.md](MARKDOWN_LINTING.md) for complete documentation.
 1. Follow existing patterns for method naming and structure
 1. Update relevant tests when modifying component behavior
 1. Ensure phpcs compliance before committing (run `composer lint`)
-1. **Ensure markdown linting compliance** when editing .md files (run `composer lint:md:fix`)
+1. **Ensure markdown linting compliance** when editing .md files (run `composer format:md:fix`, then `composer lint:md`)
 1. Use type hints and return types (PHP 8.1+ features)
 1. Document public methods with clear docblocks
 

--- a/FEATURE_ROADMAP.md
+++ b/FEATURE_ROADMAP.md
@@ -253,7 +253,7 @@ $request = new CalendarRequest();
 
 **File:** `src/ApiClient.php`
 
-```php
+````php
 <?php
 
 namespace LiturgicalCalendar\Components;
@@ -434,7 +434,7 @@ class ApiClient
         self::$instance = null;
     }
 }
-```
+````
 
 #### Phase 0.1: Update MetadataProvider to use ApiClient
 

--- a/MARKDOWN_LINTING.md
+++ b/MARKDOWN_LINTING.md
@@ -8,7 +8,8 @@ Markdown linting dependencies are managed via npm. Install them with:
 
 ```bash
 npm install
-```text
+```
+
 This will install:
 
 - `markdownlint-cli2` - CLI tool for linting markdown files
@@ -36,7 +37,8 @@ Check all markdown files for issues:
 composer lint:md
 # or directly with npm
 npm run lint:md
-```text
+```
+
 ### Auto-fix Issues
 
 Automatically fix many markdown issues:
@@ -45,7 +47,37 @@ Automatically fix many markdown issues:
 composer lint:md:fix
 # or directly with npm
 npm run lint:md:fix
-```text
+```
+
+### Formatting (Prettier)
+
+Two tools, deliberately kept separate:
+
+| Tool                | Scripts                      | Owns                                                  |
+| ------------------- | ---------------------------- | ----------------------------------------------------- |
+| `markdownlint-cli2` | `lint:md`, `lint:md:fix`     | the `.markdownlint.yml` rules — MD013, MD029, MD040 … |
+| `prettier`          | `format:md`, `format:md:fix` | formatting — table alignment (MD060), blank lines     |
+
+They are complementary, not alternatives, because **`markdownlint-cli2 --fix` cannot repair MD060.**
+Run it on a misaligned table and it reports the error but changes nothing; alignment would otherwise
+have to be done by hand. `composer format:md:fix` does it mechanically, and its output passes
+`lint:md` with zero errors. Prettier does **not** fix MD013 line length — that still needs a human
+edit, because it runs with `--prose-wrap=preserve`.
+
+Run prettier **first**, then markdownlint:
+
+```bash
+composer format:md:fix
+composer lint:md
+```
+
+**Prettier is configured for markdown only, on purpose.** The scripts pass
+`--embedded-language-formatting=off` so fenced PHP samples in the docs are left exactly as written,
+rather than reformatted against prettier's defaults instead of the PSR-12 ruleset phpcs enforces. For
+the same reason there is deliberately **no `.prettierrc`** — a config file would be picked up by an
+editor's format-on-save and would start silently reformatting `src/`. Keep the options as CLI flags
+in the scripts, and keep source out via `.prettierignore`.
+
 ### Excluded Directories
 
 The following directories are automatically excluded from linting:
@@ -81,7 +113,8 @@ The markdown linting hook is configured in `captainhook.json`:
         }
     ]
 }
-```text
+```
+
 This ensures markdown linting only runs when `.md` files are staged for commit.
 
 ### Workflow Example
@@ -107,7 +140,8 @@ composer lint:md:fix
 # Re-stage and commit
 git add README.md
 git commit -m "Update README"
-```text
+```
+
 ## Common Linting Errors
 
 ### MD013 - Line Too Long
@@ -124,27 +158,29 @@ git commit -m "Update README"
 
 **Fix**: Add blank lines before and after code blocks:
 
-```markdown
+````markdown
 Some text here.
 
 ```bash
 command here
-```text
-More text here.
+```
 
-```text
+More text here.
+````
+
 ### MD040 - Fenced Code Should Have Language
 
 **Error**: Fenced code blocks should specify a language
 
 **Fix**: Add language identifier after opening backticks:
 
-```markdown
+````markdown
 ```bash
 #!/bin/bash
 echo "Hello"
-```text
-```text
+```
+````
+
 ### MD032 - Lists Need Blank Lines
 
 **Error**: Lists should be surrounded by blank lines
@@ -159,7 +195,8 @@ Some text here.
 - List item 3
 
 More text here.
-```text
+```
+
 ## Integration with Other Linting
 
 The project uses multiple linting tools:
@@ -185,7 +222,8 @@ git commit --no-verify
 
 # Skip pre-push hooks
 git push --no-verify
-```text
+```
+
 **Warning**: Skipping hooks may result in commits that fail CI/CD checks.
 
 ## Updating Markdown Rules
@@ -205,7 +243,8 @@ If the markdown linting hook doesn't run:
 ```bash
 # Reinstall captainhook hooks
 vendor/bin/captainhook install -f
-```text
+```
+
 ### npm Command Not Found
 
 If `composer lint:md` fails with "npm: command not found":
@@ -220,7 +259,8 @@ brew install node
 
 # Then install dependencies:
 npm install
-```text
+```
+
 ### Too Many Errors
 
 If you have many markdown files with errors:
@@ -233,7 +273,8 @@ composer lint:md:fix
 composer lint:md
 
 # Fix remaining errors manually
-```text
+```
+
 ## See Also
 
 - **CLAUDE.md** - Markdown standards section

--- a/MARKDOWN_LINTING.md
+++ b/MARKDOWN_LINTING.md
@@ -266,13 +266,16 @@ npm install
 If you have many markdown files with errors:
 
 ```bash
-# Auto-fix what can be fixed automatically
+# Format first — this is what fixes MD060 table alignment
+composer format:md:fix
+
+# Then auto-fix the markdownlint rules prettier does not own
 composer lint:md:fix
 
 # Review remaining errors
 composer lint:md
 
-# Fix remaining errors manually
+# Fix remaining errors manually (MD013 line length in particular)
 ```
 
 ## See Also

--- a/PSR_COMPATIBILITY.md
+++ b/PSR_COMPATIBILITY.md
@@ -68,14 +68,14 @@ Defines interface for sending PSR-7 requests and returning PSR-7 responses.
 
 This section provides a comprehensive view of all PSR standards we'll implement:
 
-| PSR        | Standard                 | Purpose                   | Priority | Complexity |
-|------------|--------------------------|---------------------------|----------|------------|
-| **PSR-7**  | HTTP Message Interfaces  | Request/Response objects  | High     | Medium     |
-| **PSR-17** | HTTP Factories           | Create PSR-7 objects      | High     | Low        |
-| **PSR-18** | HTTP Client              | Send HTTP requests        | High     | Medium     |
-| **PSR-3**  | Logger Interface         | Structured logging        | Medium   | Low        |
-| **PSR-6**  | Caching Interface        | Cache pool abstraction    | Low      | Medium     |
-| **PSR-16** | Simple Cache             | Simplified cache interface| Low      | Low        |
+| PSR        | Standard                | Purpose                    | Priority | Complexity |
+| ---------- | ----------------------- | -------------------------- | -------- | ---------- |
+| **PSR-7**  | HTTP Message Interfaces | Request/Response objects   | High     | Medium     |
+| **PSR-17** | HTTP Factories          | Create PSR-7 objects       | High     | Low        |
+| **PSR-18** | HTTP Client             | Send HTTP requests         | High     | Medium     |
+| **PSR-3**  | Logger Interface        | Structured logging         | Medium   | Low        |
+| **PSR-6**  | Caching Interface       | Cache pool abstraction     | Low      | Medium     |
+| **PSR-16** | Simple Cache            | Simplified cache interface | Low      | Low        |
 
 ---
 
@@ -97,7 +97,8 @@ This section provides a comprehensive view of all PSR standards we'll implement:
 
 ```bash
 composer require nyholm/psr7
-```text
+```
+
 ### 2. PSR-18 HTTP Client: **Decision Required**
 
 #### Option A: Guzzle 7+ (Recommended)
@@ -105,7 +106,8 @@ composer require nyholm/psr7
 ```bash
 composer require guzzlehttp/guzzle:^7.0
 composer require guzzlehttp/psr7  # For Guzzle's PSR-7 implementation
-```text
+```
+
 **Pros:**
 
 - Industry standard, most popular PHP HTTP client
@@ -125,7 +127,8 @@ composer require guzzlehttp/psr7  # For Guzzle's PSR-7 implementation
 ```bash
 composer require symfony/http-client
 composer require nyholm/psr7  # Already included above
-```text
+```
+
 **Pros:**
 
 - Part of Symfony ecosystem
@@ -144,7 +147,8 @@ composer require nyholm/psr7  # Already included above
 ```bash
 composer require php-http/curl-client
 composer require nyholm/psr7
-```text
+```
+
 **Pros:**
 
 - Lightweight, minimal dependencies
@@ -163,7 +167,8 @@ composer require nyholm/psr7
 ```bash
 composer require php-http/discovery
 composer require psr/http-client-implementation  # Virtual package
-```text
+```
+
 **Pros:**
 
 - Client-agnostic approach
@@ -193,7 +198,8 @@ composer require psr/http-client-implementation  # Virtual package
 
 ```bash
 composer require monolog/monolog:^3.0
-```text
+```
+
 **Pros:**
 
 - Industry standard for PHP logging
@@ -221,12 +227,14 @@ $logger = new Logger('liturgical-calendar');
 $logger->pushHandler(new StreamHandler('php://stderr', Logger::WARNING));
 $logger->pushHandler(new RotatingFileHandler('/var/log/litcal/app.log', 7, Logger::DEBUG));
 $logger->pushProcessor(new IntrospectionProcessor());
-```text
+```
+
 #### Option B: Symfony Logger
 
 ```bash
 composer require symfony/monolog-bundle  # Or standalone
-```text
+```
+
 **Pros:**
 
 - Part of Symfony ecosystem
@@ -243,7 +251,8 @@ composer require symfony/monolog-bundle  # Or standalone
 
 ```bash
 composer require psr/log:^3.0
-```text
+```
+
 **Pros:**
 
 - Minimal dependency
@@ -262,7 +271,8 @@ use Psr\Log\NullLogger;
 
 // Default fallback
 $logger = $logger ?? new NullLogger();
-```text
+```
+
 **Pros:**
 
 - Built into PSR-3 package
@@ -291,7 +301,8 @@ $logger = $logger ?? new NullLogger();
 
 ```bash
 composer require symfony/cache:^6.0 || ^7.0
-```text
+```
+
 **Pros:**
 
 - Implements both PSR-6 (CacheItemPoolInterface) and PSR-16 (CacheInterface)
@@ -333,7 +344,8 @@ $cache = new ChainAdapter([
     new RedisAdapter($redis, 'litcal', 7200),
     new FilesystemAdapter('litcal', 86400)
 ]);
-```text
+```
+
 #### Option B: PSR-6/PSR-16 Simple Implementations
 
 **For PSR-6:**
@@ -342,12 +354,14 @@ $cache = new ChainAdapter([
 composer require cache/filesystem-adapter
 composer require cache/redis-adapter
 composer require cache/apcu-adapter
-```text
+```
+
 **For PSR-16:**
 
 ```bash
 composer require symfony/cache  # Includes PSR-16 SimpleCache
-```text
+```
+
 **Pros:**
 
 - Lightweight, focused packages
@@ -384,7 +398,8 @@ class ArrayCache implements CacheInterface
 
     // ... implement other PSR-16 methods
 }
-```text
+```
+
 **Pros:**
 
 - No dependencies
@@ -402,7 +417,8 @@ class ArrayCache implements CacheInterface
 ```bash
 composer require psr/simple-cache:^3.0
 composer require psr/cache:^3.0
-```text
+```
+
 **Pros:**
 
 - Minimal dependencies
@@ -431,15 +447,15 @@ composer require psr/cache:^3.0
 
 ### Overview of Implementation Phases
 
-| Phase | Focus | Duration | Dependencies |
-|-------|-------|----------|--------------|
-| **Phase 1** | HTTP Client Abstraction | Week 1 | PSR-7, PSR-17, PSR-18 |
-| **Phase 2** | Dependency Injection | Week 1 | - |
-| **Phase 3** | Code Refactoring | Week 2 | Phase 1, 2 |
-| **Phase 4** | Testing | Week 2 | Phase 3 |
-| **Phase 5** | Logging Integration | Week 3 | PSR-3 |
-| **Phase 6** | Caching Integration | Week 3-4 | PSR-6, PSR-16 |
-| **Phase 7** | Middleware & Polish | Week 4 | All phases |
+| Phase       | Focus                   | Duration | Dependencies          |
+| ----------- | ----------------------- | -------- | --------------------- |
+| **Phase 1** | HTTP Client Abstraction | Week 1   | PSR-7, PSR-17, PSR-18 |
+| **Phase 2** | Dependency Injection    | Week 1   | -                     |
+| **Phase 3** | Code Refactoring        | Week 2   | Phase 1, 2            |
+| **Phase 4** | Testing                 | Week 2   | Phase 3               |
+| **Phase 5** | Logging Integration     | Week 3   | PSR-3                 |
+| **Phase 6** | Caching Integration     | Week 3-4 | PSR-6, PSR-16         |
+| **Phase 7** | Middleware & Polish     | Week 4   | All phases            |
 
 ---
 
@@ -478,7 +494,8 @@ interface HttpClientInterface
      */
     public function post(string $url, array|string $body, array $headers = []): ResponseInterface;
 }
-```text
+```
+
 #### 1.2 Create PSR-18 Implementation
 
 **Location:** `src/Http/PsrHttpClient.php`
@@ -542,7 +559,8 @@ class PsrHttpClient implements HttpClientInterface
         }
     }
 }
-```text
+```
+
 #### 1.3 Create Custom Exception
 
 **Location:** `src/Http/HttpException.php`
@@ -554,7 +572,8 @@ namespace LiturgicalCalendar\Components\Http;
 class HttpException extends \Exception
 {
 }
-```text
+```
+
 #### 1.4 Create Legacy Adapter (Backward Compatibility)
 
 **Location:** `src/Http/FileGetContentsClient.php`
@@ -658,7 +677,8 @@ class FileGetContentsClient implements HttpClientInterface
         return $parsed;
     }
 }
-```text
+```
+
 ### Phase 2: Dependency Injection Setup (Week 1)
 
 #### 2.1 Create HTTP Client Factory
@@ -738,7 +758,8 @@ class HttpClientFactory
         return new PsrHttpClient($guzzle, $psr17Factory, $psr17Factory);
     }
 }
-```text
+```
+
 ### Phase 3: Refactor Existing Code (Week 2)
 
 #### 3.1 Update CalendarSelect.php
@@ -751,7 +772,8 @@ if ($metadataRaw === false) {
     throw new \Exception("Error fetching metadata from {$this->metadataUrl}");
 }
 $metadataJSON = json_decode($metadataRaw, true);
-```text
+```
+
 **After:**
 
 ```php
@@ -766,7 +788,8 @@ if ($response->getStatusCode() !== 200) {
 
 $metadataRaw = $response->getBody()->getContents();
 $metadataJSON = json_decode($metadataRaw, true);
-```text
+```
+
 **Constructor changes:**
 
 ```php
@@ -777,7 +800,8 @@ public function __construct(
     $this->httpClient = $httpClient ?? HttpClientFactory::create();
     // ... existing constructor code
 }
-```text
+```
+
 #### 3.2 Update ApiOptions/Input/Locale.php
 
 Similar refactoring pattern as CalendarSelect.php
@@ -836,7 +860,8 @@ class CalendarSelectTest extends TestCase
         // ... test assertions
     }
 }
-```text
+```
+
 ---
 
 ### Phase 5: Logging Integration (Week 3)
@@ -866,7 +891,8 @@ trait LoggerAwareTrait
         return $this->logger ?? new NullLogger();
     }
 }
-```text
+```
+
 #### 5.2 Logging HTTP Client Decorator
 
 **Location:** `src/Http/LoggingHttpClient.php`
@@ -958,7 +984,8 @@ class LoggingHttpClient implements HttpClientInterface
         }
     }
 }
-```text
+```
+
 #### 5.3 Update HttpClientFactory with Logging
 
 **Location:** `src/Http/HttpClientFactory.php` (enhancement)
@@ -972,7 +999,8 @@ public static function createWithLogging(
 
     return new LoggingHttpClient($baseClient, $logger);
 }
-```text
+```
+
 #### 5.4 Update CalendarSelect with Logger Support
 
 **Location:** `src/CalendarSelect.php` (enhancement)
@@ -1000,7 +1028,8 @@ class CalendarSelect
         // ... existing constructor code
     }
 }
-```text
+```
+
 #### 5.5 Logging Events to Track
 
 **HTTP Operations:**
@@ -1170,7 +1199,8 @@ class CachingHttpClient implements HttpClientInterface
         ]);
     }
 }
-```text
+```
+
 #### 6.3 In-Memory Array Cache Implementation
 
 **Location:** `src/Cache/ArrayCache.php`
@@ -1263,7 +1293,8 @@ class ArrayCache implements CacheInterface
         return $this->get($key) !== null;
     }
 }
-```text
+```
+
 #### 6.4 Update HttpClientFactory with Caching Support
 
 **Location:** `src/Http/HttpClientFactory.php` (enhancement)
@@ -1282,7 +1313,8 @@ public static function createWithCaching(
     $cachedClient = new CachingHttpClient($baseClient, $cache, $ttl, $logger);
     return new LoggingHttpClient($cachedClient, $logger);
 }
-```text
+```
+
 #### 6.5 Update CalendarSelect with Cache Support
 
 **Location:** `src/CalendarSelect.php` (enhancement)
@@ -1314,7 +1346,8 @@ class CalendarSelect
         // ... existing constructor code
     }
 }
-```text
+```
+
 #### 6.6 Cache Strategy Configuration
 
 **Recommended Cache TTLs:**
@@ -1348,7 +1381,8 @@ $cache = new Psr16Cache(
 
 $httpClient = HttpClientFactory::createWithCaching($cache, 3600);
 $calendar = new CalendarSelect(null, $httpClient);
-```text
+```
+
 ---
 
 ### Phase 7: Middleware & Polish (Week 4)
@@ -1432,7 +1466,8 @@ class CircuitBreakerHttpClient implements HttpClientInterface
         }
     }
 }
-```text
+```
+
 ---
 
 ## Migration Timeline
@@ -1513,7 +1548,8 @@ class CircuitBreakerHttpClient implements HttpClientInterface
         "php-http/discovery": "^1.0 - Automatic PSR implementation discovery"
     }
 }
-```text
+```
+
 **Benefits:**
 
 - Library remains lightweight
@@ -1536,7 +1572,8 @@ class CircuitBreakerHttpClient implements HttpClientInterface
         "symfony/cache": "^6.0 || ^7.0"
     }
 }
-```text
+```
+
 **Benefits:**
 
 - Guaranteed PSR compliance out of the box
@@ -1601,21 +1638,24 @@ class CircuitBreakerHttpClient implements HttpClientInterface
 ```php
 $calendar = new CalendarSelect();
 // Works exactly as before with file_get_contents fallback
-```text
+```
+
 #### With PSR Client (Optional)
 
 ```php
 $httpClient = HttpClientFactory::createWithGuzzle();
 $calendar = new CalendarSelect(null, $httpClient);
 // Uses PSR-18 HTTP client
-```text
+```
+
 #### Custom Client Injection
 
 ```php
 $myCustomClient = new MyCustomPsrClient();
 $calendar = new CalendarSelect(null, $myCustomClient);
 // Maximum flexibility
-```text
+```
+
 ### Breaking Changes: **NONE**
 
 All changes are additive. Existing code continues to work unchanged.
@@ -1679,7 +1719,8 @@ class CachingHttpClient implements HttpClientInterface
         return $response;
     }
 }
-```text
+```
+
 #### Retry Middleware
 
 ```php
@@ -1708,7 +1749,8 @@ class RetryHttpClient implements HttpClientInterface
         }
     }
 }
-```text
+```
+
 ### Phase 5: Async Support (Future)
 
 For future async calendar data fetching when multiple API calls needed.
@@ -1754,17 +1796,19 @@ Prevent memory exhaustion from large responses
 
 ## Conclusion
 
-This comprehensive implementation plan provides a clear path to full PSR compliance (PSR-7, PSR-17, PSR-18, PSR-3, PSR-6, PSR-16) while maintaining backward compatibility. The phased approach allows for incremental adoption and testing. The architecture supports future enhancements through middleware while keeping the core library lightweight and flexible.
+This comprehensive implementation plan provides a clear path to full PSR compliance (PSR-7, PSR-17, PSR-18, PSR-3, PSR-6, PSR-16)
+while maintaining backward compatibility. The phased approach allows for incremental adoption and testing. The architecture
+supports future enhancements through middleware while keeping the core library lightweight and flexible.
 
 ### Summary of Recommendations
 
-| Component | Recommended Implementation | Fallback | Rationale |
-|-----------|---------------------------|----------|-----------|
-| **HTTP Messages** | `nyholm/psr7` | - | Lightweight, user preference, PHPStan compatible |
-| **HTTP Client** | `guzzlehttp/guzzle` ^7.0 | `file_get_contents()` | Industry standard, middleware ecosystem |
-| **Logging** | `monolog/monolog` ^3.0 | `NullLogger` | Professional logging, Guzzle integration |
-| **Caching** | `symfony/cache` ^6.0/^7.0 | `ArrayCache` | PSR-6 & PSR-16, multi-backend support |
-| **Discovery** | `php-http/discovery` (optional) | Manual injection | Auto-discovery convenience |
+| Component         | Recommended Implementation      | Fallback              | Rationale                                        |
+| ----------------- | ------------------------------- | --------------------- | ------------------------------------------------ |
+| **HTTP Messages** | `nyholm/psr7`                   | -                     | Lightweight, user preference, PHPStan compatible |
+| **HTTP Client**   | `guzzlehttp/guzzle` ^7.0        | `file_get_contents()` | Industry standard, middleware ecosystem          |
+| **Logging**       | `monolog/monolog` ^3.0          | `NullLogger`          | Professional logging, Guzzle integration         |
+| **Caching**       | `symfony/cache` ^6.0/^7.0       | `ArrayCache`          | PSR-6 & PSR-16, multi-backend support            |
+| **Discovery**     | `php-http/discovery` (optional) | Manual injection      | Auto-discovery convenience                       |
 
 ### Key Benefits of This Approach
 
@@ -1802,7 +1846,8 @@ CircuitBreakerHttpClient (prevents cascading failures)
 PsrHttpClient (PSR-18 implementation)
     ↓
 Guzzle (actual HTTP requests)
-```text
+```
+
 ### Next Steps
 
 1. **Review and Approve** this comprehensive game plan
@@ -1905,7 +1950,8 @@ src/Http/
 ├── PsrHttpClient.php
 ├── FileGetContentsClient.php
 └── HttpClientFactory.php
-```text
+```
+
 **Files Modified**:
 
 - `composer.json` - Added PSR dependencies
@@ -1919,7 +1965,8 @@ src/Http/
 PHPUnit 12.4.3
 OK (54 tests, 224 assertions, 1 skipped)
 PHPStan Level 10: No errors
-```text
+```
+
 **Unit Tests Created** (2025-11-15):
 
 - `tests/Http/HttpExceptionTest.php` - 5 tests for exception handling
@@ -1972,7 +2019,8 @@ src/Http/
 
 tests/Http/
 └── LoggingHttpClientTest.php (9 tests)
-```text
+```
+
 **Files Modified**:
 
 - `src/Http/HttpClientFactory.php` - Added `createWithLogging()` method
@@ -2000,7 +2048,8 @@ tests/Http/
 PHPUnit 12.4.3
 OK (63 tests, 274 assertions, 1 skipped)
 PHPStan Level 10: No errors
-```text
+```
+
 **Usage Example**:
 
 ```php
@@ -2016,7 +2065,8 @@ $logger->pushHandler(new StreamHandler('php://stderr', Logger::INFO));
 $calendar = new CalendarSelect([], null, $logger);
 
 // All HTTP requests will now be logged automatically
-```text
+```
+
 **Next Steps**:
 
 - Update README with logging examples
@@ -2059,7 +2109,8 @@ tests/Cache/
 
 tests/Http/
 └── CachingHttpClientTest.php (8 tests)
-```text
+```
+
 **Files Modified**:
 
 - `composer.json` - Added psr/cache ^3.0
@@ -2099,7 +2150,8 @@ tests/Http/
 PHPUnit 12.4.3
 OK (84 tests, 362 assertions, 1 skipped)
 PHPStan Level 10: No errors
-```text
+```
+
 **Test Coverage**:
 
 - ✅ ArrayCache: All PSR-16 methods, TTL expiry, data type support
@@ -2131,7 +2183,8 @@ $html1 = $calendar->getSelect();
 
 // Second call - cache hit, no API request
 $html2 = $calendar->getSelect();
-```text
+```
+
 **Advanced Usage with Symfony Cache**:
 
 ```php
@@ -2149,7 +2202,8 @@ $httpClient = HttpClientFactory::createWithCaching($filesystemCache, 3600);
 
 // Use with CalendarSelect
 $calendar = new CalendarSelect([], $httpClient);
-```text
+```
+
 **Cache TTL Recommendations**:
 
 - **Calendar Metadata**: 1 hour (3600 seconds) - changes infrequently
@@ -2202,7 +2256,8 @@ tests/Http/
 └── CircuitBreakerHttpClientTest.php (11 tests)
 
 UPGRADE.md (comprehensive migration guide)
-```text
+```
+
 **Files Modified**:
 
 - `src/Http/HttpClientFactory.php` - Added `createWithRetry()`, `createWithCircuitBreaker()`, `createProductionClient()` methods
@@ -2243,7 +2298,8 @@ $httpClient = HttpClientFactory::createWithRetry(
     useExponentialBackoff: true,
     retryStatusCodes: [500, 502, 503, 504]
 );
-```text
+```
+
 1. **createWithCircuitBreaker()** - Prevent cascading failures:
 
 ```php
@@ -2252,7 +2308,8 @@ $httpClient = HttpClientFactory::createWithCircuitBreaker(
     recoveryTimeout: 60,
     successThreshold: 2
 );
-```text
+```
+
 1. **createProductionClient()** - Full middleware stack:
 
 ```php
@@ -2263,7 +2320,8 @@ $httpClient = HttpClientFactory::createProductionClient(
     maxRetries: 3,
     failureThreshold: 5
 );
-```text
+```
+
 **Middleware Stack Architecture** (createProductionClient):
 
 ```text
@@ -2278,7 +2336,8 @@ $httpClient = HttpClientFactory::createProductionClient(
 │  ↓                                   │
 │ Base HTTP Client (Guzzle/Native)   │ ← Makes actual requests
 └─────────────────────────────────────┘
-```text
+```
+
 **Test Results**:
 
 ```text
@@ -2292,7 +2351,8 @@ Test Coverage:
 ✅ Integration with logging
 ✅ Proper exception handling
 ✅ Timing verification (backoff strategies)
-```text
+```
+
 **Usage Examples**:
 
 **Basic Retry:**
@@ -2303,7 +2363,8 @@ use LiturgicalCalendar\Components\CalendarSelect;
 
 $httpClient = HttpClientFactory::createWithRetry(maxRetries: 3);
 $calendar = new CalendarSelect([], $httpClient);
-```text
+```
+
 **Circuit Breaker:**
 
 ```php
@@ -2312,7 +2373,8 @@ $httpClient = HttpClientFactory::createWithCircuitBreaker(
     recoveryTimeout: 60
 );
 $calendar = new CalendarSelect([], $httpClient);
-```text
+```
+
 **Production Setup with All Features:**
 
 ```php
@@ -2333,7 +2395,8 @@ $httpClient = HttpClientFactory::createProductionClient(
 );
 
 $calendar = new CalendarSelect([], $httpClient, $logger, $cache);
-```text
+```
+
 **Migration Guide**:
 
 - Created comprehensive UPGRADE.md with examples

--- a/README.md
+++ b/README.md
@@ -248,16 +248,16 @@ from the Liturgical Calendar API `/calendars` route. Can be instantiated passing
 with the following keys:
 
 - `locale`: The locale to use for the calendar select. Defaults to 'en'.
-               This is the locale that will be used to translate and order the names of the countries.
-               This should be a valid PHP locale string, such as 'en' or 'es' or 'en_US' or 'es_ES'.
+  This is the locale that will be used to translate and order the names of the countries.
+  This should be a valid PHP locale string, such as 'en' or 'es' or 'en_US' or 'es_ES'.
 - `class`: The class or classes to apply to the select element, default `calendarSelect`.
-- `id`:    The id to apply to the select element, default `calendarSelect`.
-- `name`:  The name to apply to the select element, default `calendarSelect`.
+- `id`: The id to apply to the select element, default `calendarSelect`.
+- `name`: The name to apply to the select element, default `calendarSelect`.
 - `setOptions`: The type of select options to return. Must be a valid case of the `OptionsType` enum. Valid cases are
-                   `OptionsType::NATIONS`, `OptionsType::DIOCESES`, `OptionsType::DIOCESES_FOR_NATION`, or `OptionsType::ALL`, default `OptionsType::ALL`.
+  `OptionsType::NATIONS`, `OptionsType::DIOCESES`, `OptionsType::DIOCESES_FOR_NATION`, or `OptionsType::ALL`, default `OptionsType::ALL`.
 - `nationFilter`: When `setOptions` is set to `OptionsType::DIOCESES_FOR_NATION`, this is the nation for which dioceses will be filtered, default `null`.
-                     This option MUST be set, and MUST NOT be `null` or empty, when `setOptions` is set to `OptionsType::DIOCESES_FOR_NATION`,
-                     otherwise an exception will occur.
+  This option MUST be set, and MUST NOT be `null` or empty, when `setOptions` is set to `OptionsType::DIOCESES_FOR_NATION`,
+  otherwise an exception will occur.
 - `selectedOption`: Set one of the options in the select as the default selected option, by value, default `null`.
 - `label`: A boolean indicating whether to include a label element or not, default `false`.
 - `labelText`: The text to use for the label element, default `"Select a calendar"`.
@@ -422,7 +422,7 @@ We can change the `locale` for the `ApiOptions` component, which will affect:
 
 - the display values of the `locale` select element, so that the language names in the select options are displayed according to the given locale
 - the display values of the `eternal_high_priest` select element (since the final value is a boolean, the display values are localized
-    text representations of the underlying boolean values that are sent to the API)
+  text representations of the underlying boolean values that are sent to the API)
 - the display values of the `epiphany` select element (which are descriptive to make them more comprehensible)
 - the display values of the `ascension` and `corpus_christ` select elements ("Sunday" and "Thursday" will be displayed according to the given locale)
 
@@ -548,6 +548,7 @@ echo $apiOptions->getForm();
 > ```
 
 <!-- break blockquotes -->
+
 > [!NOTE]
 > Other than setting the `as` html element as a string value in the `formLabel` option, or enabling the `formLabel` with a boolean value,
 > we can also set `formLabel` to an associative array with the desired options.
@@ -755,19 +756,20 @@ To this end, a number of CSS classes are created by default in the resulting tab
   rather than relying on the browser to calculate the width automatically.
 - the first column has a default class of `rotate` which allows for a CSS rule that will rotate the text such as:
 
-   ```css
-   #LitCalTable td.rotate div {
-     writing-mode: vertical-rl;
-     transform: rotate(180.0deg);
-   }
-   ```
+  ```css
+  #LitCalTable td.rotate div {
+    writing-mode: vertical-rl;
+    transform: rotate(180.0deg);
+  }
+  ```
 
-   Additionally, if the first column grouping is set to `Grouping::BY_MONTH`
-   (see [Chainable methods](https://github.com/Liturgical-Calendar/liturgy-components-php#chainable-methods) below),
-   each cell of the column will have class `month`.
-   If instead the grouping is set to `Grouping::BY_LITURGICAL_SEASON`,
-   each cell of the column will have additional classes `season {LITURGICAL_SEASON}`
-   where `{LITURGICAL_SEASON}` is a value of `ADVENT`, `CHRISTMAS`, `LENT`, `EASTER_TRIDUUM`, `EASTER` or `ORDINARY_TIME`.
+  Additionally, if the first column grouping is set to `Grouping::BY_MONTH`
+  (see [Chainable methods](https://github.com/Liturgical-Calendar/liturgy-components-php#chainable-methods) below),
+  each cell of the column will have class `month`.
+  If instead the grouping is set to `Grouping::BY_LITURGICAL_SEASON`,
+  each cell of the column will have additional classes `season {LITURGICAL_SEASON}`
+  where `{LITURGICAL_SEASON}` is a value of `ADVENT`, `CHRISTMAS`, `LENT`, `EASTER_TRIDUUM`, `EASTER` or `ORDINARY_TIME`.
+
 - if Month header rows are enabled, each Month header cell will have a class of `monthHeader`
 - Date column cells have a class of `dateEntry`
 - Event details column cells have a class of `eventDetails liturgicalGrade_{GRADE}` where `{GRADE}` is the numerical rank of the festivity, where:
@@ -785,7 +787,7 @@ To this end, a number of CSS classes are created by default in the resulting tab
 > [!NOTE]
 > The WebCalendar component currently suppresses the `grade_display` for celebrations of rank 7,
 > since it is more explanatory than actually useful for display in a web calendar,
-> having a value along the lines of *'celebration with precedence over solemnities'*.
+> having a value along the lines of _'celebration with precedence over solemnities'_.
 
 #### Chainable methods
 
@@ -826,7 +828,7 @@ use LiturgicalCalendar\Components\WebCalendar\GradeDisplay;
   - `Grouping::BY_MONTH`: the first column will contain month groupings
   - `Grouping::BY_LITURGICAL_SEASON`: the first column will contain liturgical season groupings
 - `psalterWeekGrouping(bool $boolVal = true)`: sets whether the psalter week column is produced.
-   It is always the last column, and liturgical events within the same Psalter week are grouped together.
+  It is always the last column, and liturgical events within the same Psalter week are grouped together.
 - `removeHeaderRow(bool $removeHeaderRow = true)`: sets whether the header row should be removed from the table
 - `removeCaption(bool $removeCaption = true)`: sets whether the table caption should be removed from the table
 - `seasonColor(ColorAs $colorAs)`: sets how the season color is applied to the table. Can take an enum value of:
@@ -850,6 +852,7 @@ use LiturgicalCalendar\Components\WebCalendar\GradeDisplay;
   A bitwise combination of columns would look like: `seasonColorColumns(Column::LITURGICAL_SEASON->value | Column::DATE->value | Column::PSALTER_WEEK->value)`.
   As a convenience, we have a `Column::ALL` enum case that represents the OR'd value of all columns,
   as well as a `Column::NONE` enum case that represents a zero value, effectively disabling all columns from any season color effects.
+
 - `eventColor(ColorAs $colorAs)`: sets how the color for the single liturgical celebration is applied to the table.
   See `seasonColor` above for the `ColorAs` enum cases.
 - `eventColorColumns(Columns|int $columnFlags = Column::NONE)`: sets which columns should be affected by the `eventColor` settings.

--- a/README.md
+++ b/README.md
@@ -942,9 +942,10 @@ composer parallel-lint     # Check PHP syntax
 This project enforces consistent markdown formatting. To lint markdown files:
 
 ```bash
-npm install                # Install markdown linting dependencies (first time only)
-composer lint:md           # Check markdown files
-composer lint:md:fix       # Auto-fix markdown issues
+npm install                # Install markdown tooling (first time only)
+composer format:md:fix     # Format with prettier — run this FIRST (owns MD060 table alignment)
+composer lint:md:fix       # Auto-fix the markdownlint rules prettier does not own
+composer lint:md           # Check for anything left, e.g. MD013 line length
 ```
 
 See [MARKDOWN_LINTING.md](MARKDOWN_LINTING.md) for detailed markdown linting documentation.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -452,11 +452,11 @@ With caching enabled:
 
 ### Recommended Cache TTLs
 
-| Data Type           | Recommended TTL   | Rationale                                    |
-|---------------------|-------------------|----------------------------------------------|
-| Calendar Metadata   | 24 hours (86400s) | Changes infrequently                         |
-| Locale Information  | 24 hours (86400s) | Very stable (supported locales per calendar) |
-| Calendar Data       | 1 week (604800s)  | Liturgical calendar data is stable long-term |
+| Data Type          | Recommended TTL   | Rationale                                    |
+| ------------------ | ----------------- | -------------------------------------------- |
+| Calendar Metadata  | 24 hours (86400s) | Changes infrequently                         |
+| Locale Information | 24 hours (86400s) | Very stable (supported locales per calendar) |
+| Calendar Data      | 1 week (604800s)  | Liturgical calendar data is stable long-term |
 
 ### Example Performance Gains
 

--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,8 @@
         "lint:fix": "phpcbf",
         "lint:md": "npm run lint:md",
         "lint:md:fix": "npm run lint:md:fix",
+        "format:md": "npm run format:md",
+        "format:md:fix": "npm run format:md:fix",
         "analyse": "phpstan analyse",
         "parallel-lint": "parallel-lint --exclude .git --exclude vendor .",
         "test": "phpunit --testdox --display-warnings",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,13 @@
     "private": true,
     "scripts": {
         "lint:md": "markdownlint-cli2 \"**/*.md\" \"#vendor/**\" \"#node_modules/**\"",
-        "lint:md:fix": "markdownlint-cli2 --fix \"**/*.md\" \"#vendor/**\" \"#node_modules/**\""
+        "lint:md:fix": "markdownlint-cli2 --fix \"**/*.md\" \"#vendor/**\" \"#node_modules/**\"",
+        "format:md": "prettier --check --embedded-language-formatting=off --prose-wrap=preserve \"**/*.md\"",
+        "format:md:fix": "prettier --write --embedded-language-formatting=off --prose-wrap=preserve \"**/*.md\""
     },
     "devDependencies": {
-        "markdownlint-cli2": "^0.15.0"
+        "markdownlint-cli2": "^0.15.0",
+        "prettier": "^3.9.6"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Adds prettier alongside markdownlint, mirroring the setup in liturgy-components-js — and fixes two documents that turned out to be structurally broken.

## Why both tools

**`markdownlint-cli2 --fix` cannot repair MD060 table alignment.** Run it on a misaligned table and it reports the error and changes nothing, leaving alignment to be done by hand. Prettier does it mechanically, and its output passes `lint:md` with zero errors.

They are complementary, not alternatives, so both stay with distinct script names — `lint:md` is markdownlint, `format:md` is prettier.

| Tool | Scripts | Owns |
|------|---------|------|
| `markdownlint-cli2` | `lint:md`, `lint:md:fix` | the `.markdownlint.yml` rules — MD013, MD029, MD040 … |
| `prettier` | `format:md`, `format:md:fix` | formatting — table alignment (MD060), blank lines |

Order matters: **prettier first, then markdownlint.**

### Markdown-only, on purpose

The scripts pass `--embedded-language-formatting=off` so fenced PHP samples keep the style phpcs enforces rather than prettier’s defaults. And there is deliberately **no `.prettierrc`** — a config file would be picked up by an editor’s format-on-save and start silently reformatting `src/`. Options stay as CLI flags; `.prettierignore` keeps source out. Both decisions are carried over from liturgy-components-js, where they were learned the hard way.

## What adding it uncovered

Two documents were **rendering as one enormous code block**.

`MARKDOWN_LINTING.md` and `PSR_COMPATIBILITY.md` closed every code block with ` ```text ` rather than a bare fence. A CommonMark closing fence carries no info string, so those blocks never closed — everything after the first fence was swallowed. `PSR_COMPATIBILITY.md` had **122 fences and zero bare ones**.

**The corruption hid itself from the linter.** Everything after the unclosed fence counted as code, so markdownlint never examined it and reported both files clean. That is why it survived unnoticed.

Closing the fences properly made the content visible, and markdownlint immediately found real MD031/MD032/MD013 violations underneath — which prettier then fixed, bar one 358-character line that needed a human edit (prettier runs `--prose-wrap=preserve` and will not wrap prose).

### One thing worth reviewing closely

Prettier’s own first instinct here was wrong, and I did not take it. Faced with a document-wide unclosed fence it escalated the opener to four backticks and appended a closer at EOF — technically valid, but it made the entire file a code block. I reverted that and fixed the actual cause. The two nested markdown-in-markdown demos in `MARKDOWN_LINTING.md` get the longer outer fence the convention calls for.

## Verification

- `composer lint:md` — 0 errors
- `composer format:md` — clean, and idempotent
- `npm run lint:md` / `npm run format:md` — same
- Fence balance checked programmatically: both repaired files now have equal openers and closers, and **no closer carries an info string**
- `composer test` unchanged at 240 tests / 11 errors — the pre-existing `lugano_ch` crash, untouched by this

Documented in `MARKDOWN_LINTING.md` and `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved Markdown formatting across project documentation, including code blocks, tables, lists, and spacing.
  * Clarified Markdown quality-checking and formatting guidance.

* **Chores**
  * Added commands to check and automatically fix Markdown formatting.
  * Added formatting exclusions for generated, dependency, and catalogue files.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->